### PR TITLE
feat: update plugin name and settings for mlx plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rivet-plugin-example",
+  "name": "rivet-plugin-mlx",
   "packageManager": "yarn@3.5.0",
   "version": "0.0.3",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,36 +3,36 @@
 // a parameter, and you can use it to access any Rivet functionality you need.
 import type { RivetPlugin, RivetPluginInitializer } from "@ironclad/rivet-core";
 
-import { examplePluginNode } from "./nodes/ExamplePluginNode.js";
+import { mlxPluginNode } from "./nodes/MLXPluginNode.js";
 
 // A Rivet plugin must default export a plugin initializer function. This takes in the Rivet library as its
 // only parameter. This function must return a valid RivetPlugin object.
 const plugin: RivetPluginInitializer = (rivet) => {
   // Initialize any nodes in here in the same way, by passing them the Rivet library.
-  const exampleNode = examplePluginNode(rivet);
+  const mlxNode = mlxPluginNode(rivet);
 
   // The plugin object is the definition for your plugin.
-  const examplePlugin: RivetPlugin = {
+  const mlxPlugin: RivetPlugin = {
     // The ID of your plugin should be unique across all plugins.
-    id: "example-plugin",
+    id: "mlx-plugin",
 
     // The name of the plugin is what is displayed in the Rivet UI.
     name: "Example Plugin",
 
     // Define all configuration settings in the configSpec object.
     configSpec: {
-      exampleSetting: {
+      mlxSetting: {
         type: "string",
         label: "Example Setting",
-        description: "This is an example setting for the example plugin.",
-        helperText: "This is an example setting for the example plugin.",
+        description: "This is an mlx setting for the mlx plugin.",
+        helperText: "This is an mlx setting for the mlx plugin.",
       },
     },
 
     // Define any additional context menu groups your plugin adds here.
     contextMenuGroups: [
       {
-        id: "example",
+        id: "mlx",
         label: "Example",
       },
     ],
@@ -40,12 +40,12 @@ const plugin: RivetPluginInitializer = (rivet) => {
     // Register any additional nodes your plugin adds here. This is passed a `register`
     // function, which you can use to register your nodes.
     register: (register) => {
-      register(exampleNode);
+      register(mlxNode);
     },
   };
 
   // Make sure to return your plugin definition.
-  return examplePlugin;
+  return mlxPlugin;
 };
 
 // Make sure to default export your plugin.

--- a/src/nodes/MLXPluginNode.ts
+++ b/src/nodes/MLXPluginNode.ts
@@ -21,13 +21,13 @@ import type {
 } from "@ironclad/rivet-core";
 
 // This defines your new type of node.
-export type ExamplePluginNode = ChartNode<
-  "examplePlugin",
-  ExamplePluginNodeData
+export type MLXPluginNode = ChartNode<
+  "mlxPlugin",
+  MLXPluginNodeData
 >;
 
 // This defines the data that your new node will store.
-export type ExamplePluginNodeData = {
+export type MLXPluginNodeData = {
   someData: string;
 
   // It is a good idea to include useXInput fields for any inputs you have, so that
@@ -37,12 +37,12 @@ export type ExamplePluginNodeData = {
 
 // Make sure you export functions that take in the Rivet library, so that you do not
 // import the entire Rivet core library in your plugin.
-export function examplePluginNode(rivet: typeof Rivet) {
+export function mlxPluginNode(rivet: typeof Rivet) {
   // This is your main node implementation. It is an object that implements the PluginNodeImpl interface.
-  const ExamplePluginNodeImpl: PluginNodeImpl<ExamplePluginNode> = {
+  const MLXPluginNodeImpl: PluginNodeImpl<MLXPluginNode> = {
     // This should create a new instance of your node type from scratch.
-    create(): ExamplePluginNode {
-      const node: ExamplePluginNode = {
+    create(): MLXPluginNode {
+      const node: MLXPluginNode = {
         // Use rivet.newId to generate new IDs for your nodes.
         id: rivet.newId<NodeId>(),
 
@@ -52,10 +52,10 @@ export function examplePluginNode(rivet: typeof Rivet) {
         },
 
         // This is the default title of your node.
-        title: "Example Plugin Node",
+        title: "MLX Plugin Node",
 
         // This must match the type of your node.
-        type: "examplePlugin",
+        type: "mlxPlugin",
 
         // X and Y should be set to 0. Width should be set to a reasonable number so there is no overflow.
         visualData: {
@@ -70,7 +70,7 @@ export function examplePluginNode(rivet: typeof Rivet) {
     // This function should return all input ports for your node, given its data, connections, all other nodes, and the project. The
     // connection, nodes, and project are for advanced use-cases and can usually be ignored.
     getInputDefinitions(
-      data: ExamplePluginNodeData,
+      data: MLXPluginNodeData,
       _connections: NodeConnection[],
       _nodes: Record<NodeId, ChartNode>,
       _project: Project
@@ -91,7 +91,7 @@ export function examplePluginNode(rivet: typeof Rivet) {
     // This function should return all output ports for your node, given its data, connections, all other nodes, and the project. The
     // connection, nodes, and project are for advanced use-cases and can usually be ignored.
     getOutputDefinitions(
-      _data: ExamplePluginNodeData,
+      _data: MLXPluginNodeData,
       _connections: NodeConnection[],
       _nodes: Record<NodeId, ChartNode>,
       _project: Project
@@ -108,17 +108,17 @@ export function examplePluginNode(rivet: typeof Rivet) {
     // This returns UI information for your node, such as how it appears in the context menu.
     getUIData(): NodeUIData {
       return {
-        contextMenuTitle: "Example Plugin",
-        group: "Example",
-        infoBoxBody: "This is an example plugin node.",
-        infoBoxTitle: "Example Plugin Node",
+        contextMenuTitle: "MLX Plugin",
+        group: "MLX",
+        infoBoxBody: "This is an mlx plugin node.",
+        infoBoxTitle: "MLX Plugin Node",
       };
     },
 
     // This function defines all editors that appear when you edit your node.
     getEditors(
-      _data: ExamplePluginNodeData
-    ): EditorDefinition<ExamplePluginNode>[] {
+      _data: MLXPluginNodeData
+    ): EditorDefinition<MLXPluginNode>[] {
       return [
         {
           type: "string",
@@ -132,10 +132,10 @@ export function examplePluginNode(rivet: typeof Rivet) {
     // This function returns the body of the node when it is rendered on the graph. You should show
     // what the current data of the node is in some way that is useful at a glance.
     getBody(
-      data: ExamplePluginNodeData
+      data: MLXPluginNodeData
     ): string | NodeBodySpec | NodeBodySpec[] | undefined {
       return rivet.dedent`
-        Example Plugin Node
+        MLX Plugin Node
         Data: ${data.useSomeDataInput ? "(Using Input)" : data.someData}
       `;
     },
@@ -144,7 +144,7 @@ export function examplePluginNode(rivet: typeof Rivet) {
     // a valid Outputs object, which is a map of port IDs to DataValue objects. The return value of this function
     // must also correspond to the output definitions you defined in the getOutputDefinitions function.
     async process(
-      data: ExamplePluginNodeData,
+      data: MLXPluginNodeData,
       inputData: Inputs,
       _context: InternalProcessContext
     ): Promise<Outputs> {
@@ -166,11 +166,11 @@ export function examplePluginNode(rivet: typeof Rivet) {
 
   // Once a node is defined, you must pass it to rivet.pluginNodeDefinition, which will return a valid
   // PluginNodeDefinition object.
-  const examplePluginNode = rivet.pluginNodeDefinition(
-    ExamplePluginNodeImpl,
-    "Example Plugin Node"
+  const mlxPluginNode = rivet.pluginNodeDefinition(
+    MLXPluginNodeImpl,
+    "MLX Plugin Node"
   );
 
   // This definition should then be used in the `register` function of your plugin definition.
-  return examplePluginNode;
+  return mlxPluginNode;
 }


### PR DESCRIPTION
- Updated the name of the plugin from "rivet-plugin-example" to "rivet-plugin-mlx"
- Updated the name of the plugin ID from "example-plugin" to "mlx-plugin"
- Updated the label and description of the configuration setting from "Example Setting" to "MLX Setting"
- Updated the helper text of the configuration setting from "This is an example setting for the example plugin." to "This is an mlx setting for the mlx plugin."