### PR TITLE
feat: update MLX plugin configuration and add new options for host and port

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -100,34 +100,140 @@ function mlxPluginNode(rivet) {
   return mlxPluginNode2;
 }
 
+// src/nodes/MLXGenerateNode.ts
+var mlxGenerate = (rivet) => {
+  const impl = {
+    create() {
+      const node = {
+        id: rivet.newId(),
+        data: {
+          model: "",
+          useModelInput: false
+        },
+        title: "MLX Generate",
+        type: "mlxGenerate",
+        visualData: {
+          x: 0,
+          y: 0,
+          width: 250
+        }
+      };
+      return node;
+    },
+    getInputDefinitions(data) {
+      const inputs = [];
+      if (data.useModelInput) {
+        inputs.push({
+          id: "model",
+          dataType: "string",
+          title: "Model"
+        });
+      }
+      return inputs;
+    },
+    getOutputDefinitions(data) {
+      let outputs = [
+        {
+          id: "output",
+          dataType: "string",
+          title: "Output",
+          description: "The output from MLX."
+        },
+        {
+          id: "prompt",
+          dataType: "string",
+          title: "Prompt",
+          description: "The full prompt, with formattting, that was sent to MLX."
+        },
+        {
+          id: "messages-sent",
+          dataType: "chat-message[]",
+          title: "Messages Sent",
+          description: "The messages sent to MLX, including the system prompt."
+        },
+        {
+          id: "all-messages",
+          dataType: "chat-message[]",
+          title: "All Messages",
+          description: "All messages, including the reply from MLX."
+        }
+      ];
+      return outputs;
+    },
+    getEditors() {
+      return [
+        {
+          type: "string",
+          dataKey: "model",
+          label: "Model",
+          useInputToggleDataKey: "useModelInput",
+          helperMessage: "The LLM model to use in MLX."
+        }
+      ];
+    },
+    getBody(data) {
+      return rivet.dedent`
+        Model: ${data.useModelInput ? "(From Input)" : data.model || "Unset!"}
+      `;
+    },
+    getUIData() {
+      return {
+        contextMenuTitle: "MLX Generate",
+        group: "MLX",
+        infoBoxBody: "This is an MLX Generate node using /v1/chat/completions.",
+        infoBoxTitle: "MLX Generate Node"
+      };
+    },
+    async process(data, inputData, context) {
+      let outputs = {};
+      return outputs;
+    }
+  };
+  return rivet.pluginNodeDefinition(impl, "MLX Generate");
+};
+
 // src/index.ts
 var plugin = (rivet) => {
-  const mlxNode = mlxPluginNode(rivet);
   const mlxPlugin = {
-    // The ID of your plugin should be unique across all plugins.
     id: "mlx-plugin",
-    // The name of the plugin is what is displayed in the Rivet UI.
     name: "MLX Plugin",
-    // Define all configuration settings in the configSpec object.
     configSpec: {
-      mlxSetting: {
+      host: {
         type: "string",
-        label: "MLX Setting",
-        description: "This is an mlx setting for the mlx plugin.",
-        helperText: "This is an mlx setting for the mlx plugin."
+        label: "HOST",
+        default: "127.0.0.1",
+        description: "Host for the HTTP server (default: 127.0.0.1)",
+        helperText: "Host for the HTTP server (default: 127.0.0.1)"
+      },
+      port: {
+        type: "string",
+        label: "PORT",
+        default: "8080",
+        description: "Port for the HTTP server (default: 8080)",
+        helperText: "Port for the HTTP server (default: 8080)"
+      },
+      adapter_file: {
+        type: "string",
+        label: "ADAPTER_FILE",
+        description: "Optional path for the trained adapter weights.",
+        helperText: "Optional path for the trained adapter weights."
+      },
+      model: {
+        type: "string",
+        label: "MODEL",
+        description: "The path to the MLX model weights, tokenizer, and config",
+        helperText: "The path to the MLX model weights, tokenizer, and config"
       }
     },
-    // Define any additional context menu groups your plugin adds here.
     contextMenuGroups: [
       {
         id: "mlx",
         label: "MLX"
       }
     ],
-    // Register any additional nodes your plugin adds here. This is passed a `register`
-    // function, which you can use to register your nodes.
     register: (register) => {
-      register(mlxNode);
+      register(mlxPluginNode(rivet));
+      register(mlxGenerate(rivet));
     }
   };
   return mlxPlugin;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,53 @@
-// It is important that you only import types from @ironclad/rivet-core, and not
-// any of the actual Rivet code. Rivet is passed into the initializer function as
-// a parameter, and you can use it to access any Rivet functionality you need.
+// usage: server.py [-h] --model MODEL [--adapter-file ADAPTER_FILE] [--host HOST] [--port PORT]
+//
+// MLX Http Server.
+//
+// options:
+//   -h, --help            show this help message and exit
+//   --model MODEL         The path to the MLX model weights, tokenizer, and config
+//   --adapter-file ADAPTER_FILE
+//                         Optional path for the trained adapter weights.
+//   --host HOST           Host for the HTTP server (default: 127.0.0.1)
+//   --port PORT           Port for the HTTP server (default: 8080)
+
 import type { RivetPlugin, RivetPluginInitializer } from "@ironclad/rivet-core";
 
-import { mlxPluginNode } from "./nodes/MLXPluginNode.js";
+import { mlxPluginNode } from "./nodes/MLXPluginNode";
+import { mlxGenerate } from "./nodes/MLXGenerateNode";
 
-// A Rivet plugin must default export a plugin initializer function. This takes in the Rivet library as its
-// only parameter. This function must return a valid RivetPlugin object.
 const plugin: RivetPluginInitializer = (rivet) => {
-  // Initialize any nodes in here in the same way, by passing them the Rivet library.
-  const mlxNode = mlxPluginNode(rivet);
-
-  // The plugin object is the definition for your plugin.
   const mlxPlugin: RivetPlugin = {
-    // The ID of your plugin should be unique across all plugins.
     id: "mlx-plugin",
-
-    // The name of the plugin is what is displayed in the Rivet UI.
     name: "MLX Plugin",
-
-    // Define all configuration settings in the configSpec object.
     configSpec: {
-      mlxSetting: {
+      host: {
         type: "string",
-        label: "MLX Setting",
-        description: "This is an mlx setting for the mlx plugin.",
-        helperText: "This is an mlx setting for the mlx plugin.",
+        label: "HOST",
+        default: "127.0.0.1",
+        description: "Host for the HTTP server (default: 127.0.0.1)",
+        helperText: "Host for the HTTP server (default: 127.0.0.1)",
+      },
+      port: {
+        type: "string",
+        label: "PORT",
+        default: "8080",
+        description: "Port for the HTTP server (default: 8080)",
+        helperText: "Port for the HTTP server (default: 8080)",
+      },
+      adapter_file: {
+        type: "string",
+        label: "ADAPTER_FILE",
+        description: "Optional path for the trained adapter weights.",
+        helperText: "Optional path for the trained adapter weights.",
+      },
+      model: {
+        type: "string",
+        label: "MODEL",
+        description: "The path to the MLX model weights, tokenizer, and config",
+        helperText: "The path to the MLX model weights, tokenizer, and config",
       },
     },
 
-    // Define any additional context menu groups your plugin adds here.
     contextMenuGroups: [
       {
         id: "mlx",
@@ -37,16 +55,13 @@ const plugin: RivetPluginInitializer = (rivet) => {
       },
     ],
 
-    // Register any additional nodes your plugin adds here. This is passed a `register`
-    // function, which you can use to register your nodes.
     register: (register) => {
-      register(mlxNode);
+      register(mlxPluginNode(rivet));
+      register(mlxGenerate(rivet));
     },
   };
 
-  // Make sure to return your plugin definition.
   return mlxPlugin;
 };
 
-// Make sure to default export your plugin.
 export default plugin;

--- a/src/nodes/MLXGenerateNode.ts
+++ b/src/nodes/MLXGenerateNode.ts
@@ -1,0 +1,144 @@
+// usage: generate.py [-h] [--model MODEL] [--trust-remote-code] [--eos-token EOS_TOKEN] [--prompt PROMPT]
+//                    [--max-tokens MAX_TOKENS] [--temp TEMP] [--seed SEED] [--ignore-chat-template] [--colorize]
+//
+// LLM inference script
+//
+// options:
+//   -h, --help            show this help message and exit
+//   --model MODEL         The path to the local model directory or Hugging Face repo.
+//   --trust-remote-code   Enable trusting remote code for tokenizer
+//   --eos-token EOS_TOKEN
+//                         End of sequence token for tokenizer
+//   --prompt PROMPT       Message to be processed by the model
+//   --max-tokens MAX_TOKENS, -m MAX_TOKENS
+//                         Maximum number of tokens to generate
+//   --temp TEMP           Sampling temperature
+//   --seed SEED           PRNG seed
+//   --ignore-chat-template
+//                         Use the raw prompt without the tokenizer's chat template.
+//   --colorize            Colorize output based on T[0] probability
+
+import type {
+  ChartNode,
+  ChatMessage,
+  ChatMessageMessagePart,
+  EditorDefinition,
+  NodeId,
+  NodeInputDefinition,
+  NodeOutputDefinition,
+  NodeUIData,
+  Outputs,
+  PluginNodeImpl,
+  PortId,
+  Rivet,
+} from "@ironclad/rivet-core";
+
+export type MLXGenerateNodeData = {
+  model: string;
+  useModelInput?: boolean;
+};
+
+export type MLXGenerateNode = ChartNode<"mlxGenerate", MLXGenerateNodeData>;
+
+export const mlxGenerate = (rivet: typeof Rivet) => {
+  const impl: PluginNodeImpl<MLXGenerateNode> = {
+    create(): MLXGenerateNode {
+      const node: MLXGenerateNode = {
+        id: rivet.newId<NodeId>(),
+        data: {
+          model: "",
+          useModelInput: false,
+        },
+        title: "MLX Generate",
+        type: "mlxGenerate",
+        visualData: {
+          x: 0,
+          y: 0,
+          width: 250,
+        },
+      };
+      return node;
+    },
+
+    getInputDefinitions(data): NodeInputDefinition[] {
+      const inputs: NodeInputDefinition[] = [];
+
+      if (data.useModelInput) {
+        inputs.push({
+          id: "model" as PortId,
+          dataType: "string",
+          title: "Model",
+        });
+      }
+
+      return inputs;
+    },
+
+    getOutputDefinitions(data): NodeOutputDefinition[] {
+      let outputs: NodeOutputDefinition[] = [
+        {
+          id: "output" as PortId,
+          dataType: "string",
+          title: "Output",
+          description: "The output from MLX.",
+        },
+        {
+          id: "prompt" as PortId,
+          dataType: "string",
+          title: "Prompt",
+          description:
+            "The full prompt, with formattting, that was sent to MLX.",
+        },
+        {
+          id: "messages-sent" as PortId,
+          dataType: "chat-message[]",
+          title: "Messages Sent",
+          description: "The messages sent to MLX, including the system prompt.",
+        },
+        {
+          id: "all-messages" as PortId,
+          dataType: "chat-message[]",
+          title: "All Messages",
+          description: "All messages, including the reply from MLX.",
+        },
+      ];
+
+      return outputs;
+    },
+
+    getEditors(): EditorDefinition<MLXGenerateNode>[] {
+      return [
+        {
+          type: "string",
+          dataKey: "model",
+          label: "Model",
+          useInputToggleDataKey: "useModelInput",
+          helperMessage: "The LLM model to use in MLX.",
+        },
+      ];
+    },
+
+    getBody(data) {
+      return rivet.dedent`
+        Model: ${data.useModelInput ? "(From Input)" : data.model || "Unset!"}
+      `;
+    },
+
+    getUIData(): NodeUIData {
+      return {
+        contextMenuTitle: "MLX Generate",
+        group: "MLX",
+        infoBoxBody: "This is an MLX Generate node using /v1/chat/completions.",
+        infoBoxTitle: "MLX Generate Node",
+      };
+    },
+
+    async process(data, inputData, context): Promise<Outputs> {
+      let outputs: Outputs = {};
+
+      return outputs;
+    },
+  };
+
+  return rivet.pluginNodeDefinition(impl, "MLX Generate");
+};


### PR DESCRIPTION
The MLX plugin configuration has been updated to include new options for the host and port of the HTTP server. The default values for host and port are "127.0.0.1" and "8080" respectively. Additionally, an optional path for the trained adapter weights has been added as "ADAPTER_FILE". These changes allow for more flexibility and customization when using the MLX plugin.