### PR TITLE
feat: update MLXGenerateNodeData type and add validation for required fields

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -211,18 +211,6 @@ var plugin = (rivet) => {
         default: "8080",
         description: "Port for the HTTP server (default: 8080)",
         helperText: "Port for the HTTP server (default: 8080)"
-      },
-      adapter_file: {
-        type: "string",
-        label: "ADAPTER_FILE",
-        description: "Optional path for the trained adapter weights.",
-        helperText: "Optional path for the trained adapter weights."
-      },
-      model: {
-        type: "string",
-        label: "MODEL",
-        description: "The path to the MLX model weights, tokenizer, and config",
-        helperText: "The path to the MLX model weights, tokenizer, and config"
       }
     },
     contextMenuGroups: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,18 +34,6 @@ const plugin: RivetPluginInitializer = (rivet) => {
         description: "Port for the HTTP server (default: 8080)",
         helperText: "Port for the HTTP server (default: 8080)",
       },
-      adapter_file: {
-        type: "string",
-        label: "ADAPTER_FILE",
-        description: "Optional path for the trained adapter weights.",
-        helperText: "Optional path for the trained adapter weights.",
-      },
-      model: {
-        type: "string",
-        label: "MODEL",
-        description: "The path to the MLX model weights, tokenizer, and config",
-        helperText: "The path to the MLX model weights, tokenizer, and config",
-      },
     },
 
     contextMenuGroups: [

--- a/src/nodes/MLXGenerateNode.ts
+++ b/src/nodes/MLXGenerateNode.ts
@@ -36,6 +36,24 @@ import type {
 export type MLXGenerateNodeData = {
   model: string;
   useModelInput?: boolean;
+
+  eosToken?: string;
+  useEosToken?: boolean;
+
+  maxTokens?: number;
+  useMaxTokens?: boolean;
+
+  temp?: number;
+  useTemp?: boolean;
+
+  seed?: number;
+  useSeed?: boolean;
+
+  ignoreChatTemplate?: boolean;
+  useIgnoreChatTemplate?: boolean;
+
+  colorize?: boolean;
+  useColorize?: boolean;
 };
 
 export type MLXGenerateNode = ChartNode<"mlxGenerate", MLXGenerateNodeData>;
@@ -48,6 +66,7 @@ export const mlxGenerate = (rivet: typeof Rivet) => {
         data: {
           model: "",
           useModelInput: false,
+          maxTokens: 1024,
         },
         title: "MLX Generate",
         type: "mlxGenerate",
@@ -135,6 +154,20 @@ export const mlxGenerate = (rivet: typeof Rivet) => {
 
     async process(data, inputData, context): Promise<Outputs> {
       let outputs: Outputs = {};
+      const host = context.getPluginConfig("host") || "http://127.0.0.1";
+      if (!host.trim()) {
+        throw new Error("No host set!");
+      }
+
+      const port = context.getPluginConfig("port") || "8080";
+      if (!port.trim()) {
+        throw new Error("No port set!");
+      }
+
+      const model = rivet.getInputOrData(data, inputData, "model");
+      if (!model.trim()) {
+        throw new Error("No model set!");
+      }
 
       return outputs;
     },


### PR DESCRIPTION
The MLXGenerateNodeData type has been updated to include additional optional fields: eosToken, useEosToken, maxTokens, useMaxTokens, temp, useTemp, seed, useSeed, ignoreChatTemplate, useIgnoreChatTemplate, colorize, and useColorize.

In the process method of the MLXGenerateNode class, validation has been added for the required fields: host, port, and model. If any of these fields are not set, an error will be thrown.

Additionally, the adapter_file and model fields have been removed from the plugin configuration options as they are no longer needed.